### PR TITLE
added check to allow template strings without variables

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -79,15 +79,19 @@ var VersionFile = function () {
       // and make sure the corresponding values have been provided in `this.data`
       var dataKeys = Object.keys(this.data);
       var templateVariablesRegex = /<%= (.+?) %>/g;
-      var variablesNotPopulated = template.match(templateVariablesRegex).map(function (variable) {
-        return variable.replace('<%=', '');
-      }).map(function (variable) {
-        return variable.replace('%>', '');
-      }).map(function (variable) {
-        return variable.trim();
-      }).map(getRootVariableForNestedObjects).filter(function (variable) {
-        return dataKeys.indexOf(variable) === -1;
-      });
+      var regexMatches = template.match(templateVariablesRegex);
+      var variablesNotPopulated = [];
+      if (regexMatches) {
+        variablesNotPopulated = regexMatches.map(function (variable) {
+          return variable.replace('<%=', '');
+        }).map(function (variable) {
+          return variable.replace('%>', '');
+        }).map(function (variable) {
+          return variable.trim();
+        }).map(getRootVariableForNestedObjects).filter(function (variable) {
+          return dataKeys.indexOf(variable) === -1;
+        });
+      }
 
       if (variablesNotPopulated.length > 0) {
         var variableCollocation = variablesNotPopulated.length > 1 ? 'variables' : 'variable';

--- a/src/index.js
+++ b/src/index.js
@@ -59,13 +59,16 @@ class VersionFile {
     // and make sure the corresponding values have been provided in `this.data`
     const dataKeys = Object.keys(this.data);
     const templateVariablesRegex = /<%= (.+?) %>/g;
-    const variablesNotPopulated = template
-      .match(templateVariablesRegex)
-      .map(variable => variable.replace('<%=', ''))
-      .map(variable => variable.replace('%>', ''))
-      .map(variable => variable.trim())
-      .map(getRootVariableForNestedObjects)
-      .filter(variable => dataKeys.indexOf(variable) === -1);
+    const regexMatches = template.match(templateVariablesRegex);
+    let variablesNotPopulated = [];
+    if (regexMatches) {
+      variablesNotPopulated = regexMatches
+        .map(variable => variable.replace('<%=', ''))
+        .map(variable => variable.replace('%>', ''))
+        .map(variable => variable.trim())
+        .map(getRootVariableForNestedObjects)
+        .filter(variable => dataKeys.indexOf(variable) === -1);
+    }
 
     if (variablesNotPopulated.length > 0) {
       const variableCollocation = variablesNotPopulated.length > 1 ? 'variables' : 'variable';

--- a/test/data.js
+++ b/test/data.js
@@ -73,4 +73,13 @@ describe('Version File Webpack Plugin - Data', () => {
     expect(plugin.data.version).to.equal('4.5.6');
     expect(plugin.data.buildDate).to.equal('Today');
   });
+
+  it('it allows using template strings without variables', () => {
+    const stringVersion = '1.33.7';
+    const plugin = new VersionFile({
+      templateString: stringVersion,
+    });
+
+    expect(() => plugin.apply()).not.to.throw();
+  })
 });


### PR DESCRIPTION
When specifying a template string without a variable an error is thrown

configuration:
```javascript
const version = '1.2.3';
new VersionFile({
     output: './version',
     templateString: `${version}`,
     verbose: true,
 }),
```

```
TypeError: Cannot read property 'map' of null
    at VersionFile.apply (~myDir/node_modules/webpack-version-file/lib/index.js:82:73)
```

This is not the best test since it only checks if there is not an error (and also a version file is created during the test)
However I didn't want to add huge test changes without talking back to you.
I guess we need a mock for the fs package that is used in the `writeFunction()`