### PR TITLE
Fix wrong url leading to spam page

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ There are two ways in which you can define your own template:
 * using a template string
 * creating a template file
 
-In either case, the template must be written using [EJS](http://www.embeddedjs.com/) which is a JavaScript templating language. Here's a sample template:
+In either case, the template must be written using [EJS](https://ejs.co/) which is a JavaScript templating language. Here's a sample template:
 
 ```
 <%= name %>@<%= version %>


### PR DESCRIPTION
When clicking on "EJS" the user was redirected to the **wrong web page** (http://www.embeddedjs.com/), which was filled of **spam and ads**.

This PR fixes that URL to the right one (https://ejs.co/) instead.


### Before
![image](https://user-images.githubusercontent.com/33452387/212692446-97cd133a-0077-4e39-a794-0be546e32608.png)

### After
![image](https://user-images.githubusercontent.com/33452387/212692506-aa450316-200c-4ec3-adc4-5cab8148400f.png)
